### PR TITLE
refactor: Centralize model configuration in settings.py

### DIFF
--- a/server/RAG/rag_chain.py
+++ b/server/RAG/rag_chain.py
@@ -11,6 +11,7 @@ from langchain_core.runnables import RunnablePassthrough
 from langchain_core.output_parsers import StrOutputParser
 from server.prompts.prompts_rag import PROMPTS
 from server.RAG.vector_db import VectorStore
+from server.config.settings import settings
 
 # Configura logging
 logging.basicConfig(level=logging.INFO)
@@ -28,7 +29,7 @@ class ScientificRAG:
         if not groq_api_key:
             raise ValueError("GROQ_API_KEY no está configurada como variable de entorno.")
         
-        self.llm = ChatGroq(temperature=0.3, model_name="llama-3.1-8b-instant", groq_api_key=groq_api_key)
+        self.llm = ChatGroq(temperature=0.3, model_name=settings.GROQ_DEFAULT_MODEL, groq_api_key=groq_api_key)
 
     def initialize_prompt(self, social_network: str, topic: str, company_info: str, voice: str, language: str):
         self.topic = topic

--- a/server/config/settings.py
+++ b/server/config/settings.py
@@ -18,6 +18,14 @@ class Settings:
     STABILITY_API_KEY = os.getenv("STABILITY_API_KEY")
     HUGGINGFACE_API_KEY = os.getenv("HUGGINGFACE_API_KEY")
 
+    # Model Names
+    GROQ_DEFAULT_MODEL = "llama-3.1-8b-instant"
+    GROQ_AVAILABLE_MODELS = {
+        "llama-3.1-8b-instant": "Llama 3.1 (8B)",
+        "llama-3.3-70b-versatile": "Llama 3.3 (70B)",
+    }
+    HUGGINGFACE_IMAGE_MODEL = "black-forest-labs/FLUX.1-dev"
+
     # Cloudinary
     CLOUDINARY_CLOUD_NAME = os.getenv("CLOUDINARY_CLOUD_NAME")
     CLOUDINARY_API_KEY = os.getenv("CLOUDINARY_API_KEY")

--- a/server/generators/image.py
+++ b/server/generators/image.py
@@ -1,4 +1,5 @@
 import os
+from server.config.settings import settings
 from typing import Optional
 import datetime
 import requests
@@ -127,7 +128,7 @@ def generate_image_huggingface(
         )
         image = client.text_to_image(
             prompt,
-            model="black-forest-labs/FLUX.1-dev",
+            model=settings.HUGGINGFACE_IMAGE_MODEL,
         )
         # Convert PIL Image to bytes
         with BytesIO() as buffer:

--- a/server/models/post.py
+++ b/server/models/post.py
@@ -2,13 +2,14 @@ from pydantic import BaseModel
 from typing import Optional, List
 from uuid import UUID
 from datetime import datetime
+from server.config.settings import settings
 
 class ContentRequest(BaseModel):
     platform: str  
     topic: str
     audience: str  # juvenil, general, técnica
     language: str  # es, en, fr
-    model: Optional[str] = "llama-3.1-8b-instant"  # modelo de Groq seleccionado
+    model: Optional[str] = settings.GROQ_DEFAULT_MODEL  # modelo de Groq seleccionado
     include_image: Optional[bool] = False
     image_generator: Optional[str] = 'fal_ai'
     image_prompt: Optional[str] = None

--- a/server/models/science.py
+++ b/server/models/science.py
@@ -1,12 +1,13 @@
 from pydantic import BaseModel, Field
 from typing import List, Dict, Any, Optional
 from uuid import UUID
+from server.config.settings import settings
 
 class ScienceRequest(BaseModel):
     topic: str
     audience: str  
     language: str
-    model: str = Field(default="llama-3.1-8b-instant")
+    model: str = Field(default=settings.GROQ_DEFAULT_MODEL)
     max_docs: int = Field(default=5, ge=1, le=20)
 
 class SourceInfo(BaseModel):

--- a/server/routes/science.py
+++ b/server/routes/science.py
@@ -3,8 +3,9 @@ from uuid import UUID
 from typing import List
 
 from server.models.science import ScienceRequest, ScienceResponse, SciencePostDB
-from server.services.science_service import generate_science_content, AVAILABLE_MODELS
+from server.services.science_service import generate_science_content
 from server.utils.dependencies import get_current_user
+from server.config.settings import settings
 from server.utils.database import get_supabase
 
 router = APIRouter()
@@ -13,8 +14,8 @@ router = APIRouter()
 async def get_available_models():
     """Obtener modelos disponibles para generación científica"""
     return {
-        "models": list(AVAILABLE_MODELS.keys()),
-        "default": "llama-3.1-8b-instant"
+        "models": list(settings.GROQ_AVAILABLE_MODELS.keys()),
+        "default": settings.GROQ_DEFAULT_MODEL
     }
 
 @router.post("/generate", response_model=ScienceResponse)

--- a/server/services/content_service.py
+++ b/server/services/content_service.py
@@ -9,7 +9,7 @@ from uuid import UUID
 import base64
 
 async def generate_content(request: ContentRequest, user_id: UUID):
-    model_used = request.model if request.model and request.model.strip() else "llama-3.1-8b-instant"
+    model_used = request.model if request.model and request.model.strip() else settings.GROQ_DEFAULT_MODEL
     
     try:
         generated_text = generate_text(

--- a/server/services/science_service.py
+++ b/server/services/science_service.py
@@ -19,10 +19,7 @@ from langchain_chroma import Chroma
 from server.chroma_db.connection_db import client
 
 # Modelos disponibles
-AVAILABLE_MODELS = {
-    "llama-3.1-8b-instant": "llama-3.1-8b-instant",
-    "llama-3.3-70b-versatile": "llama-3.3-70b-versatile",
-}
+AVAILABLE_MODELS = settings.GROQ_AVAILABLE_MODELS
 
 # Mapeo de idioma para el prompt
 LANG_INSTRUCTIONS = {

--- a/server/utils/pipeline.py
+++ b/server/utils/pipeline.py
@@ -3,6 +3,7 @@ from server.generators.text import generate_text
 from server.generators.image import ImageGenerator
 from deep_translator import GoogleTranslator
 from server.utils.cloudinary import upload_image_bytes
+from server.config.settings import settings
 
 def translate_text(texto):
     return GoogleTranslator(source='auto', target='en').translate(texto)
@@ -11,7 +12,7 @@ def translate_text(texto):
 def run_pipeline(
     topic: str,
     platform: str,
-    model_name: str = "llama-3.1-8b-instant",
+    model_name: str = settings.GROQ_DEFAULT_MODEL,
     voice: str = "general",
     company_info: str = "",
     language: str = "es",


### PR DESCRIPTION
# 🔧 `refactor`: Centralizar la configuración de modelos

## 🎯 Contexto

Tras solucionar el error de los modelos obsoletos, se identificó que los nombres de los modelos de IA (tanto de texto como de imagen) estaban **"hardcodeados"** (escritos directamente) en múltiples archivos a lo largo del código. Esta práctica dificulta el mantenimiento y aumenta la probabilidad de errores en el futuro, como el que acabamos de solucionar.

## 🛠️ Solución Implementada

Esta Pull Request refactoriza el código para centralizar toda la configuración de los modelos en un único lugar, siguiendo el principio de **"Fuente Única de Verdad" (Single Source of Truth)**.

### 1. 📁 Creación de Configuración Central

Se ha añadido una sección **`Model Names`** en el archivo `server/config/settings.py`. Este archivo ahora es la fuente única de verdad y contiene:

*   El modelo de texto por defecto (`GROQ_DEFAULT_MODEL`).
*   Un diccionario de modelos de texto disponibles (`GROQ_AVAILABLE_MODELS`).
*   El modelo de generación de imágenes (`HUGGINGFACE_IMAGE_MODEL`).

### 2. 🔄 Refactorización del Código Fuente

Se han modificado los siguientes archivos para eliminar los nombres de modelo "hardcodeados" e importar los valores desde `settings.py`:

*   **`server/config/settings.py`**:
    *   Añadidas las nuevas variables de configuración para los modelos.

*   **`server/generators/image.py`**:
    *   Actualizado para usar `settings.HUGGINGFACE_IMAGE_MODEL` al llamar a la API de Hugging Face.

*   **`server/services/science_service.py`**:
    *   El diccionario `AVAILABLE_MODELS` ahora apunta directamente a `settings.GROQ_AVAILABLE_MODELS`.

*   **`server/services/content_service.py`**:
    *   El modelo de texto que se usa por defecto si no se especifica uno, ahora es `settings.GROQ_DEFAULT_MODEL`.

*   **`server/utils/pipeline.py`**:
    *   El modelo por defecto en la firma de la función `run_pipeline` ahora es `settings.GROQ_DEFAULT_MODEL`.

*   **`server/routes/science.py`**:
    *   El endpoint `/models` ahora obtiene la lista de modelos y el modelo por defecto directamente desde `settings`.

*   **`server/models/science.py`**:
    *   El valor por defecto para el campo `model` en el Pydantic model `ScienceRequest` se ha actualizado a `settings.GROQ_DEFAULT_MODEL`.

*   **`server/models/post.py`**:
    *   El valor por defecto para el campo `model` en el Pydantic model `ContentRequest` se ha actualizado a `settings.GROQ_DEFAULT_MODEL`.

*   **`server/RAG/rag_chain.py`**:
    *   La inicialización de `ChatGroq` ahora usa `settings.GROQ_DEFAULT_MODEL` como nombre del modelo.

## ✅ Beneficios

*   ✅ **Mantenimiento Sencillo**: Para cambiar o actualizar un modelo en el futuro, solo será necesario modificar el archivo `settings.py`.
*   ✅ **Reducción de Errores**: Se elimina el riesgo de inconsistencias al tener una única fuente de verdad para los nombres de los modelos.
*   ✅ **Mejora de la Calidad del Código**: El código es ahora más limpio, mantenible y sigue las mejores prácticas de desarrollo de software.